### PR TITLE
Updates ghc version to `9.0.2` and stackage version to `lts-19.6`.

### DIFF
--- a/http2-client.cabal
+++ b/http2-client.cabal
@@ -27,7 +27,7 @@ library
                      , bytestring >= 0.10 && < 1
                      , containers >= 0.5 && < 1
                      , deepseq >= 1.4 && < 2
-                     , http2 >= 1.6 && < 2.1
+                     , http2 >= 1.6
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
                      , mtl >= 2.2 && < 3

--- a/src/Network/HTTP2/Client.hs
+++ b/src/Network/HTTP2/Client.hs
@@ -57,7 +57,7 @@ import qualified Data.ByteString as ByteString
 import           Data.IORef.Lifted (newIORef, atomicModifyIORef', readIORef)
 import           Data.Maybe (fromMaybe)
 import           Network.HPACK as HPACK
-import           Network.HTTP2 as HTTP2
+import           Network.HTTP2.Frame as HTTP2
 import           Network.Socket (HostName, PortNumber)
 import           Network.TLS (ClientParams)
 
@@ -282,7 +282,7 @@ type PushPromiseHandler =
 -- @ _ <- (withHttp2Stream myClient $ \stream -> StreamDefinition _ _) @
 --
 -- Please refer to 'StreamStarter' and 'StreamDefinition' for more.
-withHttp2Stream :: Http2Client -> StreamStarter a
+withHttp2Stream :: Http2Client -> forall a. StreamStarter a
 withHttp2Stream = _startStream
 
 -- | Type synonym for functions that modify flags.

--- a/src/Network/HTTP2/Client/Channels.hs
+++ b/src/Network/HTTP2/Client/Channels.hs
@@ -11,7 +11,7 @@ module Network.HTTP2.Client.Channels (
 
 import           Control.Concurrent.Chan.Lifted (Chan, readChan, newChan, writeChan)
 import           Control.Exception.Lifted (Exception, throwIO)
-import           Network.HTTP2 (StreamId, FrameHeader, FramePayload, FrameTypeId, framePayloadToFrameTypeId, streamId)
+import           Network.HTTP2.Frame (FrameHeader, FramePayload, FrameTypeId, StreamId, framePayloadToFrameTypeId, streamId)
 
 import           Network.HTTP2.Client.Exceptions
 

--- a/src/Network/HTTP2/Client/Dispatch.hs
+++ b/src/Network/HTTP2/Client/Dispatch.hs
@@ -14,7 +14,7 @@ import qualified Data.IntMap as IntMap
 import           GHC.Exception (Exception)
 import           Network.HPACK as HPACK
 import qualified Network.HPACK.Token as HPACK
-import           Network.HTTP2 as HTTP2
+import           Network.HTTP2.Frame as HTTP2
 
 import           Network.HTTP2.Client.Channels
 import           Network.HTTP2.Client.Exceptions

--- a/src/Network/HTTP2/Client/FrameConnection.hs
+++ b/src/Network/HTTP2/Client/FrameConnection.hs
@@ -22,8 +22,8 @@ import           Control.Exception.Lifted (bracket)
 import           Control.Concurrent.MVar.Lifted (newMVar, takeMVar, putMVar)
 import           Control.Monad ((>=>), void, when)
 import qualified Data.ByteString as ByteString
-import           Network.HTTP2 (FrameHeader(..), FrameFlags, FramePayload, HTTP2Error, encodeInfo, decodeFramePayload)
-import qualified Network.HTTP2 as HTTP2
+import           Network.HTTP2.Frame (FrameFlags, FrameHeader (..), FramePayload, HTTP2Error, decodeFramePayload, encodeInfo)
+import qualified Network.HTTP2.Frame as HTTP2
 import           Network.Socket (HostName, PortNumber)
 import qualified Network.TLS as TLS
 

--- a/src/Network/HTTP2/Client/Helpers.hs
+++ b/src/Network/HTTP2/Client/Helpers.hs
@@ -21,7 +21,7 @@ module Network.HTTP2.Client.Helpers (
   ) where
 
 import           Data.Time.Clock (UTCTime, getCurrentTime)
-import qualified Network.HTTP2 as HTTP2
+import qualified Network.HTTP2.Frame as HTTP2
 import qualified Network.HPACK as HPACK
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString

--- a/src/Network/HTTP2/Client/RawConnection.hs
+++ b/src/Network/HTTP2/Client/RawConnection.hs
@@ -17,7 +17,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import           Data.ByteString.Lazy (fromChunks)
 import           Data.Monoid ((<>))
-import qualified Network.HTTP2 as HTTP2
+import qualified Network.HTTP2.Frame as HTTP2
 import           Network.Socket hiding (recv)
 import           Network.Socket.ByteString
 import qualified Network.TLS as TLS

--- a/stack-lts-19.6.yaml
+++ b/stack-lts-19.6.yaml
@@ -1,0 +1,8 @@
+resolver: lts-19.6
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []
+extra-include-dirs:
+    - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/ffi/

--- a/stack-lts-19.6.yaml
+++ b/stack-lts-19.6.yaml
@@ -4,5 +4,3 @@ packages:
 extra-deps: []
 flags: {}
 extra-package-dbs: []
-extra-include-dirs:
-    - /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/include/ffi/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-lts-12.6.yaml
+stack-lts-19.6.yaml


### PR DESCRIPTION
## Purpose

Updates ghc version to `9.0.2` and stackage version to `lts-19.6`.

## Changes

- Upgrades the stackage version
- Fixes deprecation warnings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
